### PR TITLE
DB rename column teachesInEnglish => no_english

### DIFF
--- a/migrations/20190208085622368-base.js
+++ b/migrations/20190208085622368-base.js
@@ -137,7 +137,7 @@ var migrationCommands = [{
         'field': 'last_name',
         'allowNull': false
       },
-      'teachesInEnglish': {
+      'no_english': {
         'type': Sequelize.BOOLEAN
       },
       'experience': {

--- a/models/student.js
+++ b/models/student.js
@@ -23,9 +23,9 @@ module.exports = (sequelize, Sequelize) => {
       type: Sequelize.STRING(127),
       allowNull: false
     },
-    teachesInEnglish: {
+    no_english: {
       type: Sequelize.BOOLEAN,
-      defaultValue: true
+      defaultValue: false
     },
     experience: {
       type: Sequelize.STRING(1000),

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test-simple": "cross-env NODE_ENV=test jest --maxWorkers=1 --forceExit",
     "migrate": "node_modules/.bin/sequelize db:migrate",
     "migrate-test": "cross-env NODE_ENV=test node_modules/.bin/sequelize db:migrate",
+    "migrate-test-undo": "cross-env NODE_ENV=test node_modules/.bin/sequelize db:migrate:undo",
     "migrate-undo": "node_modules/.bin/sequelize db:migrate:undo",
     "seed": "node_modules/.bin/sequelize db:seed:all",
     "seed-undo": "node_modules/.bin/sequelize db:seed:undo:all",

--- a/tests/api.students.test.js
+++ b/tests/api.students.test.js
@@ -156,12 +156,12 @@ describe('tests for the students controller', () => {
         describe('update and delete tests', () => {
           test('Student can update his/her own data with PUT /api/students/:id', async () => {
             const studentBefore = await db.Student.findOne({ where: { student_id: students[index].student_id } })
-            expect(studentBefore.teachesInEnglish).toBeTruthy()
+            expect(studentBefore.no_english).toBeFalsy()
 
             await api
               .put(`/api/students/${users[index].user_id}`)
               .set('Authorization', `bearer ${studentToken}`)
-              .send({ email: 'maili@hotmail.com', phone: '0402356543', experience: 'very good', teachesInEnglish: 'false'})
+              .send({ email: 'maili@hotmail.com', phone: '0402356543', experience: 'very good', no_english: 'true'})
               .expect(201)
       
             const updatedStudent = await db.Student.findOne({ where: { student_id: students[index].student_id } })


### PR DESCRIPTION
- Renamed column `teachesInEnglish => no_english` to avoid confusion in frontend
- Fixed tests
- Also added script for test db migrate-undo